### PR TITLE
fix: setup dependency checks lint rule

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -10,11 +10,12 @@
       "default",
       "!{projectRoot}/.eslintrc.json",
       "!{projectRoot}/eslint.config.js",
-      "!{projectRoot}/**/?(*.)+(spec|test).[jt]s?(x)?(.snap)",
+      "!{projectRoot}/**/?(*.)+(unit-test|spec|test).[jt]s?(x)?(.snap)",
       "!{projectRoot}/tsconfig.spec.json",
       "!{projectRoot}/jest.config.[jt]s",
       "!{projectRoot}/src/test-setup.[jt]s",
-      "!{projectRoot}/test-setup.[jt]s"
+      "!{projectRoot}/test-setup.[jt]s",
+      "!{projectRoot}/vite.config.[jt]s"
     ],
     "sharedGlobals": []
   },

--- a/projects/nx-verdaccio/.eslintrc.json
+++ b/projects/nx-verdaccio/.eslintrc.json
@@ -33,17 +33,21 @@
       "rules": {}
     },
     {
-      "files": ["*.json"],
-      "parser": "jsonc-eslint-parser",
-      "rules": {
-        "@nx/dependency-checks": "error"
-      }
-    },
-    {
       "files": ["./package.json", "./generators.json"],
       "parser": "jsonc-eslint-parser",
       "rules": {
-        "@nx/nx-plugin-checks": "error"
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "buildTargets": ["build"],
+            "ignoredDependencies": ["verdaccio"],
+            "checkMissingDependencies": true,
+            "checkObsoleteDependencies": true,
+            "checkVersionMismatches": true,
+            "includeTransitiveDependencies": true,
+            "useLocalPathsForWorkspaceDependencies": true
+          }
+        ]
       }
     }
   ]

--- a/projects/nx-verdaccio/package.json
+++ b/projects/nx-verdaccio/package.json
@@ -4,15 +4,14 @@
   "license": "MIT",
   "private": false,
   "dependencies": {
-    "@nx/devkit": "^19.6.4",
+    "@nx/devkit": "19.8.0",
     "ansis": "^3.3.2",
-    "vite": "~5.0.0",
-    "@nx/vite": "19.8.0",
-    "tslib": "^2.3.0",
+    "simple-git": "^3.27.0",
     "nx": "19.8.0",
-    "vitest": "^1.3.1",
-    "memfs": "^4.11.1",
-    "@nx/plugin": "19.8.0"
+    "@nx/plugin": "19.8.0",
+    "tslib": "^2.3.0",
+    "@code-pushup/models": "^0.50.0",
+    "verdaccio": "*"
   },
   "type": "commonjs",
   "main": "./src/index.js",

--- a/projects/nx-verdaccio/src/executors/env-teardown/executor.ts
+++ b/projects/nx-verdaccio/src/executors/env-teardown/executor.ts
@@ -3,7 +3,7 @@ import type { TeardownExecutorOptions } from './schema';
 import { teardownEnvironment } from './teardown-env';
 import { PACKAGE_NAME } from '../../plugin/constants';
 import { EXECUTOR_ENVIRONMENT_TEARDOWN } from './constants';
-import { ExecutorOutput } from '../internal/executor-output';
+import { type ExecutorOutput } from '../internal/executor-output';
 
 export async function teardownExecutor(
   options: TeardownExecutorOptions,

--- a/projects/nx-verdaccio/src/executors/env-teardown/schema.ts
+++ b/projects/nx-verdaccio/src/executors/env-teardown/schema.ts
@@ -1,4 +1,4 @@
-import { Environment } from '../env-bootstrap/npm';
+import { type Environment } from '../env-bootstrap/npm';
 
 export type TeardownExecutorOptions = Partial<
   Environment & {

--- a/projects/nx-verdaccio/src/executors/env-teardown/teardown-env.ts
+++ b/projects/nx-verdaccio/src/executors/env-teardown/teardown-env.ts
@@ -1,14 +1,14 @@
-import { Environment } from '../env-bootstrap/npm';
+import { type Environment } from '../env-bootstrap/npm';
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { isFolderInGit } from './git';
-import { ExecutorContext, logger } from '@nx/devkit';
+import { type ExecutorContext, logger } from '@nx/devkit';
 import { join } from 'node:path';
 import { VERDACCIO_REGISTRY_JSON } from '../env-bootstrap/constants';
 import { fileExists } from '../../internal/file-system';
 import { rm } from 'node:fs/promises';
 import runKillProcessExecutor from '../kill-process/executor';
 import { DEFAULT_ENVIRONMENTS_OUTPUT_DIR } from '../../plugin/constants';
-import { ExpandedPluginConfiguration } from 'nx/src/config/nx-json';
+import { type ExpandedPluginConfiguration } from 'nx/src/config/nx-json';
 import type { NxVerdaccioCreateNodeOptions } from '../../plugin/schema';
 
 export const gitClient: SimpleGit = simpleGit(process.cwd());


### PR DESCRIPTION
Setup `@nx/dependency-checks` ESLint rule to ease package.json generation.