### PR TITLE
feat: support custom target names

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,37 @@ Tag those projects accordingly:
 - Run E2E with specific environments:  
   `nx run utils-static-e2e:e2e --environmentRoot static-environments/user-lists`
 
+### Customize inferred target names
+
+The inferred Nx targets are prefixed by `nxv-`, e.g. `nxv-e2e` will run your test target (by default `e2e`) and ensure cleanup is done afterwards (`nxv-teardown`).
+Other inferred targets include `nxv-env-setup`, `nxv-env-bootstrap`, `nxv-env-install`, `nxv-pkg-install`, `nxv-verdaccio-start`, etc.
+You can find all these targets in the Nx graph (run `npx nx graph`).
+
+You may prefer to infer different target names, e.g. so you can run `e2e-test` instead of `nxv-e2e`. All target names may be customized for both environment and package targets.
+
+```jsonc
+{
+  "plugins": [
+    {
+      "plugin": "@push-based/nx-verdaccio",
+      "options": {
+        "environments": {
+          "inferredTargets": {
+            "e2e": "e2e-test", // default is "nxv-e2e"
+            "setup": "e2e-test-setup" // default is "nxv-e2e-setup"
+          }
+        },
+        "packages": {
+          "inferredTargets": {
+            "install": "npm-install" // default is "nxv-pkg-install"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
 ## Benchmarks
 
 This is a first draft of how the benchmarks will look. ATM the data set it not big enough.

--- a/e2e/nx-verdaccio-e2e/test/plugin-create-nodes.e2e.test.ts
+++ b/e2e/nx-verdaccio-e2e/test/plugin-create-nodes.e2e.test.ts
@@ -1,28 +1,13 @@
 import type { Tree } from '@nx/devkit';
-import { join } from 'node:path';
-import { afterEach, expect } from 'vitest';
 import {
   addJsLibToWorkspace,
   materializeTree,
   nxShowProjectJson,
   registerPluginInWorkspace,
 } from '@push-based/test-nx-utils';
+import { join } from 'node:path';
 import { updateProjectConfiguration } from 'nx/src/generators/utils/project-configuration';
-import {
-  TARGET_ENVIRONMENT_BOOTSTRAP,
-  TARGET_ENVIRONMENT_SETUP,
-  TARGET_PACKAGE_INSTALL,
-  TARGET_PACKAGE_PUBLISH,
-  TARGET_ENVIRONMENT_VERDACCIO_START,
-  TARGET_ENVIRONMENT_INSTALL,
-  TARGET_ENVIRONMENT_VERDACCIO_STOP,
-} from '@push-based/nx-verdaccio';
-import { teardownTestFolder } from '@push-based/test-utils';
-// eslint-disable-next-line @nx/enforce-module-boundaries
-import {
-  TARGET_ENVIRONMENT_E2E,
-  TARGET_ENVIRONMENT_TEARDOWN,
-} from '../../../projects/nx-verdaccio/src/plugin/targets/environment.targets';
+import { afterEach, expect } from 'vitest';
 
 describe('nx-verdaccio plugin create-nodes-v2', () => {
   let tree: Tree;
@@ -62,21 +47,21 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
     expect(code).toBe(0);
 
     expect(projectJson.targets).toStrictEqual({
-      [TARGET_PACKAGE_INSTALL]: expect.objectContaining({
+      'nxv-pkg-install': expect.objectContaining({
         dependsOn: [
           {
-            target: TARGET_PACKAGE_PUBLISH,
+            target: 'nxv-pkg-publish',
             params: 'forward',
           },
           {
-            target: TARGET_PACKAGE_INSTALL,
+            target: 'nxv-pkg-install',
             projects: 'dependencies',
             params: 'forward',
           },
         ],
         executor: '@push-based/nx-verdaccio:pkg-install',
       }),
-      [TARGET_PACKAGE_PUBLISH]: expect.objectContaining({
+      'nxv-pkg-publish': expect.objectContaining({
         dependsOn: [
           {
             params: 'forward',
@@ -111,8 +96,8 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
 
     expect(projectJson.targets).toStrictEqual(
       expect.not.objectContaining({
-        [TARGET_PACKAGE_INSTALL]: expect.any(Object),
-        [TARGET_PACKAGE_PUBLISH]: expect.any(Object),
+        'nxv-package-install': expect.any(Object),
+        'nxv-package-publish': expect.any(Object),
       })
     );
   });
@@ -146,8 +131,8 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
     expect(projectJsonB.tags).toStrictEqual(['publish']);
     expect(projectJsonB.targets).toStrictEqual(
       expect.objectContaining({
-        [TARGET_PACKAGE_INSTALL]: expect.any(Object),
-        [TARGET_PACKAGE_PUBLISH]: expect.any(Object),
+        'nxv-pkg-install': expect.any(Object),
+        'nxv-pkg-publish': expect.any(Object),
       })
     );
 
@@ -159,8 +144,8 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
     expect(projectJsonA.tags).toStrictEqual([]);
     expect(projectJsonA.targets).toStrictEqual(
       expect.not.objectContaining({
-        [TARGET_PACKAGE_INSTALL]: expect.any(Object),
-        [TARGET_PACKAGE_PUBLISH]: expect.any(Object),
+        'nxv-pkg-install': expect.any(Object),
+        'nxv-pkg-publish': expect.any(Object),
       })
     );
   });
@@ -194,19 +179,23 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
           dependsOn: [
             {
               params: 'forward',
-              target: TARGET_ENVIRONMENT_SETUP,
+              target: 'nxv-env-setup',
             },
           ],
         }),
-        [TARGET_ENVIRONMENT_BOOTSTRAP]: expect.objectContaining({
+        'nxv-env-bootstrap': expect.objectContaining({
           executor: '@push-based/nx-verdaccio:env-bootstrap',
+          options: {
+            verdaccioStartTarget: 'nxv-verdaccio-start',
+            verdaccioStopTarget: 'nxv-verdaccio-stop',
+          },
         }),
-        [TARGET_ENVIRONMENT_INSTALL]: expect.objectContaining({
+        'nxv-env-install': expect.objectContaining({
           dependsOn: [
             {
               params: 'forward',
               projects: 'dependencies',
-              target: TARGET_PACKAGE_INSTALL,
+              target: 'nxv-pkg-install',
             },
           ],
           executor: 'nx:run-commands',
@@ -217,10 +206,15 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
             ),
           },
         }),
-        [TARGET_ENVIRONMENT_SETUP]: expect.objectContaining({
+        'nxv-env-setup': expect.objectContaining({
           cache: true,
           executor: '@push-based/nx-verdaccio:env-setup',
-          options: {},
+          options: {
+            envBootstrapTarget: 'nxv-env-bootstrap',
+            envInstallTarget: 'nxv-env-install',
+            envPublishOnlyTarget: 'nxv-env-publish-only',
+            verdaccioStopTarget: 'nxv-verdaccio-stop',
+          },
           inputs: [
             '{projectRoot}/project.json',
             {
@@ -241,7 +235,7 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
             '{options.environmentRoot}/node_modules',
           ],
         }),
-        [TARGET_ENVIRONMENT_VERDACCIO_START]: expect.objectContaining({
+        'nxv-verdaccio-start': expect.objectContaining({
           executor: '@nx/js:verdaccio',
           options: expect.objectContaining({
             clear: true,
@@ -252,7 +246,7 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
             storage: expect.toMatchPath('tmp/environments/lib-a-e2e/storage'),
           }),
         }),
-        [TARGET_ENVIRONMENT_VERDACCIO_STOP]: expect.objectContaining({
+        'nxv-verdaccio-stop': expect.objectContaining({
           executor: '@push-based/nx-verdaccio:kill-process',
           options: {
             filePath: expect.toMatchPath(
@@ -260,7 +254,7 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
             ),
           },
         }),
-        [TARGET_ENVIRONMENT_E2E]: expect.objectContaining({
+        'nxv-e2e': expect.objectContaining({
           executor: '@push-based/nx-verdaccio:env-teardown',
           dependsOn: [
             {
@@ -269,7 +263,7 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
             },
           ],
         }),
-        [TARGET_ENVIRONMENT_TEARDOWN]: expect.objectContaining({
+        'nxv-env-teardown': expect.objectContaining({
           executor: '@push-based/nx-verdaccio:env-teardown',
         }),
       })
@@ -292,11 +286,62 @@ describe('nx-verdaccio plugin create-nodes-v2', () => {
 
     expect(projectJson.targets).toStrictEqual(
       expect.not.objectContaining({
-        [TARGET_ENVIRONMENT_BOOTSTRAP]: expect.any(Object),
-        [TARGET_ENVIRONMENT_INSTALL]: expect.any(Object),
-        [TARGET_ENVIRONMENT_SETUP]: expect.any(Object),
-        [TARGET_ENVIRONMENT_VERDACCIO_START]: expect.any(Object),
-        [TARGET_ENVIRONMENT_VERDACCIO_STOP]: expect.any(Object),
+        'nxv-env-bootstrap': expect.any(Object),
+        'nxv-env-install': expect.any(Object),
+        'nxv-env-setup': expect.any(Object),
+        'nxv-verdaccio-start': expect.any(Object),
+        'nxv-verdaccio-stop': expect.any(Object),
+      })
+    );
+  });
+
+  it('should use custom target names if provided', async () => {
+    const cwd = join(baseDir, 'add-env-targets');
+    registerPluginInWorkspace(tree, {
+      plugin: '@push-based/nx-verdaccio',
+      options: {
+        environments: {
+          inferredTargets: {
+            e2e: 'e2e-test',
+            verdaccioStart: 'verdaccio',
+            verdaccioStop: 'stop-verdaccio',
+          },
+        },
+      },
+    });
+    updateProjectConfiguration(tree, projectAE2e, {
+      root: e2eProjectARoot,
+      projectType: 'application',
+      targets: {
+        e2e: {},
+      },
+    });
+    await materializeTree(tree, cwd);
+
+    const { code, projectJson } = await nxShowProjectJson(cwd, projectAE2e);
+    expect(code).toBe(0);
+
+    expect(projectJson.targets).toStrictEqual(
+      expect.objectContaining({
+        'e2e-test': expect.any(Object),
+        verdaccio: expect.any(Object),
+        'stop-verdaccio': expect.any(Object),
+        'nxv-env-install': expect.any(Object),
+        'nxv-env-teardown': expect.any(Object),
+        'nxv-env-bootstrap': expect.objectContaining({
+          options: {
+            verdaccioStartTarget: 'verdaccio',
+            verdaccioStopTarget: 'stop-verdaccio',
+          },
+        }),
+        'nxv-env-setup': expect.objectContaining({
+          options: {
+            verdaccioStopTarget: 'stop-verdaccio',
+            envBootstrapTarget: 'nxv-env-bootstrap',
+            envInstallTarget: 'nxv-env-install',
+            envPublishOnlyTarget: 'nxv-env-publish-only',
+          },
+        }),
       })
     );
   });

--- a/projects/nx-verdaccio/src/executors/env-bootstrap/bootstrap-env.ts
+++ b/projects/nx-verdaccio/src/executors/env-bootstrap/bootstrap-env.ts
@@ -1,20 +1,19 @@
-import { join } from 'node:path';
-import {
-  type RegistryResult,
-  startVerdaccioServer,
-  type StartVerdaccioOptions,
-  type VercaddioServerResult,
-} from './verdaccio-registry';
+import { logger } from '@nx/devkit';
 import { writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
 import { formatError, formatInfo } from '../../internal/logging';
 import { VERDACCIO_REGISTRY_JSON } from './constants';
-import { logger } from '@nx/devkit';
 import {
   configureRegistry,
   type Environment,
   VERDACCIO_ENV_TOKEN,
 } from './npm';
-import { setupNpmWorkspace } from '../env-setup/npm';
+import {
+  type RegistryResult,
+  type StartVerdaccioOptions,
+  startVerdaccioServer,
+  type VercaddioServerResult,
+} from './verdaccio-registry';
 
 export type BootstrapEnvironmentOptions = StartVerdaccioOptions & Environment;
 
@@ -35,7 +34,7 @@ export async function bootstrapEnvironment(
       storage: parsedStorage,
       verbose,
       readyWhen: 'Environment ready under',
-      ...(rest as StartVerdaccioOptions),
+      ...rest,
     });
   } catch (error) {
     logger.error(

--- a/projects/nx-verdaccio/src/executors/env-bootstrap/executor.unit-test.ts
+++ b/projects/nx-verdaccio/src/executors/env-bootstrap/executor.unit-test.ts
@@ -1,11 +1,10 @@
-import runBootstrapExecutor from './executor';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import * as devkit from '@nx/devkit';
-import * as bootstrapExecutorModule from './bootstrap-env';
-import { PACKAGE_NAME } from '../../plugin/constants';
-import { TARGET_ENVIRONMENT_VERDACCIO_STOP } from '../../plugin/targets/environment.targets';
-import { MockAsyncIterableIterator } from '@push-based/test-utils';
 import { type ExecutorContext } from '@nx/devkit';
+import { MockAsyncIterableIterator } from '@push-based/test-utils';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PACKAGE_NAME } from '../../plugin/constants';
+import * as bootstrapExecutorModule from './bootstrap-env';
+import runBootstrapExecutor from './executor';
 
 describe('runBootstrapExecutor', () => {
   const e2eProjectName = 'my-lib-e2e';
@@ -17,6 +16,7 @@ describe('runBootstrapExecutor', () => {
     isVerbose: false,
     root: 'tmp/environments/test',
     projectName: e2eProjectName,
+    targetName: 'nxv-env-bootstrap',
     projectsConfigurations: {
       version: 2,
       projects: {
@@ -29,7 +29,7 @@ describe('runBootstrapExecutor', () => {
   };
   const stopVerdaccioTask = {
     project: e2eProjectName,
-    target: TARGET_ENVIRONMENT_VERDACCIO_STOP,
+    target: 'nxv-verdaccio-stop',
     configuration: undefined,
   };
 

--- a/projects/nx-verdaccio/src/executors/env-bootstrap/schema.json
+++ b/projects/nx-verdaccio/src/executors/env-bootstrap/schema.json
@@ -22,6 +22,14 @@
     "verbose": {
       "type": "boolean",
       "description": "Print additional logs"
+    },
+    "verdaccioStartTarget": {
+      "type": "string",
+      "description": "Name of target which starts the Verdaccio server"
+    },
+    "verdaccioStopTarget": {
+      "type": "string",
+      "description": "Name of target which stops the Verdaccio server"
     }
   },
   "additionalProperties": true,

--- a/projects/nx-verdaccio/src/executors/env-bootstrap/schema.ts
+++ b/projects/nx-verdaccio/src/executors/env-bootstrap/schema.ts
@@ -1,9 +1,11 @@
-import { type Environment } from './npm';
+import type { Environment } from './npm';
 
 export type BootstrapExecutorOptions = Partial<
   {
     keepServerRunning: boolean;
     printConfig: boolean;
     verbose: boolean;
+    verdaccioStartTarget?: string;
+    verdaccioStopTarget?: string;
   } & Environment
 >;

--- a/projects/nx-verdaccio/src/executors/env-setup/executor.unit-test.ts
+++ b/projects/nx-verdaccio/src/executors/env-setup/executor.unit-test.ts
@@ -1,12 +1,8 @@
-import runSetupEnvironmentExecutor from './executor';
+import * as devkit from '@nx/devkit';
+import { MockAsyncIterableIterator } from '@push-based/test-utils';
 import { beforeEach, expect, vi } from 'vitest';
 import * as executeProcessModule from '../../internal/execute-process';
-import * as devkit from '@nx/devkit';
-import {
-  TARGET_ENVIRONMENT_BOOTSTRAP,
-  TARGET_ENVIRONMENT_VERDACCIO_STOP,
-} from '../../plugin/targets/environment.targets';
-import { MockAsyncIterableIterator } from '@push-based/test-utils';
+import runSetupEnvironmentExecutor from './executor';
 import * as npmModule from './npm';
 
 vi.mock('@nx/devkit', async () => {
@@ -103,7 +99,7 @@ describe('runSetupEnvironmentExecutor', () => {
       {
         configuration: undefined,
         project: projectName,
-        target: TARGET_ENVIRONMENT_BOOTSTRAP,
+        target: 'nxv-env-bootstrap',
       },
       {
         keepServerRunning: true,
@@ -114,7 +110,7 @@ describe('runSetupEnvironmentExecutor', () => {
       {
         configuration: undefined,
         project: projectName,
-        target: TARGET_ENVIRONMENT_VERDACCIO_STOP,
+        target: 'nxv-verdaccio-stop',
       },
       {
         filePath: expect.toMatchPath(
@@ -237,7 +233,7 @@ describe('runSetupEnvironmentExecutor', () => {
       {
         configuration: undefined,
         project: 'my-lib-e2e',
-        target: TARGET_ENVIRONMENT_BOOTSTRAP,
+        target: 'nxv-env-bootstrap',
       },
       expect.objectContaining({
         environmentRoot: 'tmp/environments/my-lib-e2e',

--- a/projects/nx-verdaccio/src/executors/env-setup/schema.json
+++ b/projects/nx-verdaccio/src/executors/env-setup/schema.json
@@ -32,6 +32,22 @@
     "verbose": {
       "type": "boolean",
       "description": "Print additional logs"
+    },
+    "envBootstrapTarget": {
+      "type": "string",
+      "description": "Name of target which bootstraps the environment"
+    },
+    "envPublishOnlyTarget": {
+      "type": "string",
+      "description": "Name of target which only publishes packages for the environment"
+    },
+    "envInstallTarget": {
+      "type": "string",
+      "description": "Name of target which installs packages for the environment"
+    },
+    "verdaccioStopTarget": {
+      "type": "string",
+      "description": "Name of target which stops the Verdaccio server"
     }
   },
   "additionalProperties": true,

--- a/projects/nx-verdaccio/src/executors/env-setup/schema.ts
+++ b/projects/nx-verdaccio/src/executors/env-setup/schema.ts
@@ -1,4 +1,4 @@
-import { type Environment } from '../env-bootstrap/npm';
+import type { Environment } from '../env-bootstrap/npm';
 
 export type SetupEnvironmentExecutorOptions = Partial<
   Environment & {
@@ -6,5 +6,9 @@ export type SetupEnvironmentExecutorOptions = Partial<
     skipInstall: boolean;
     postScript: string;
     verbose: boolean;
+    envBootstrapTarget?: string;
+    envPublishOnlyTarget?: string;
+    envInstallTarget?: string;
+    verdaccioStopTarget?: string;
   }
 >;

--- a/projects/nx-verdaccio/src/index.ts
+++ b/projects/nx-verdaccio/src/index.ts
@@ -1,12 +1,5 @@
 export {
-  TARGET_ENVIRONMENT_BOOTSTRAP,
-  TARGET_ENVIRONMENT_INSTALL,
-  TARGET_ENVIRONMENT_SETUP,
-  TARGET_ENVIRONMENT_VERDACCIO_START,
-  TARGET_ENVIRONMENT_VERDACCIO_STOP,
-} from './plugin/targets/environment.targets';
-export {
-  TARGET_PACKAGE_INSTALL,
-  TARGET_PACKAGE_PUBLISH,
-} from './plugin/targets/package.targets';
+  DEFAULT_ENVIRONMENT_TARGETS,
+  DEFAULT_PACKAGE_TARGETS,
+} from './plugin/constants';
 export { createNodes, createNodesV2 } from './plugin/nx-verdaccio.plugin';

--- a/projects/nx-verdaccio/src/plugin/constants.ts
+++ b/projects/nx-verdaccio/src/plugin/constants.ts
@@ -11,3 +11,24 @@ export const DEFAULT_VERDACCIO_STORAGE_DIR = join(
   'local-registry',
   'storage'
 );
+
+export const DEFAULT_ENVIRONMENT_TARGETS = {
+  bootstrap: 'nxv-env-bootstrap',
+  install: 'nxv-env-install',
+  publishOnly: 'nxv-env-publish-only',
+  setup: 'nxv-env-setup',
+  teardown: 'nxv-env-teardown',
+  e2e: 'nxv-e2e',
+  verdaccioStart: 'nxv-verdaccio-start',
+  verdaccioStop: 'nxv-verdaccio-stop',
+} as const;
+
+export type NxVerdaccioEnvironmentTarget =
+  keyof typeof DEFAULT_ENVIRONMENT_TARGETS;
+
+export const DEFAULT_PACKAGE_TARGETS = {
+  install: 'nxv-pkg-install',
+  publish: 'nxv-pkg-publish',
+} as const;
+
+export type NxVerdaccioPackageTarget = keyof typeof DEFAULT_PACKAGE_TARGETS;

--- a/projects/nx-verdaccio/src/plugin/normalize-create-nodes-options.ts
+++ b/projects/nx-verdaccio/src/plugin/normalize-create-nodes-options.ts
@@ -1,22 +1,22 @@
-import type {
-  NxVerdaccioEnvironmentsOptions,
-  NxVerdaccioCreateNodeOptions,
-  NxVerdaccioPackagesOptions,
-} from './schema';
 import {
+  DEFAULT_ENVIRONMENT_TARGETS,
   DEFAULT_ENVIRONMENTS_OUTPUT_DIR,
   DEFAULT_OPTION_ENVIRONMENT_TARGET_NAMES,
+  DEFAULT_PACKAGE_TARGETS,
 } from './constants';
+import type {
+  NxVerdaccioCreateNodeOptions,
+  NxVerdaccioEnvironmentsOptions,
+  NxVerdaccioPackagesOptions,
+} from './schema';
+import type { WithRequired } from './utils/type.utils';
 
 export type NormalizedCreateNodeOptions = {
-  environments: Omit<
+  environments: WithRequired<
     NxVerdaccioEnvironmentsOptions,
-    'targetNames' | 'environmentsDir'
-  > &
-    Required<
-      Pick<NxVerdaccioEnvironmentsOptions, 'targetNames' | 'environmentsDir'>
-    >;
-  packages: NxVerdaccioPackagesOptions;
+    'targetNames' | 'environmentsDir' | 'inferredTargets'
+  >;
+  packages: WithRequired<NxVerdaccioPackagesOptions, 'inferredTargets'>;
 };
 
 export function normalizeCreateNodesOptions(
@@ -27,18 +27,26 @@ export function normalizeCreateNodesOptions(
 
   if (targetNames.length === 0) {
     throw new Error(
-      'Option targetNames is required in plugin options under "environments". e.g.: ["e2e"] '
+      'Option targetNames is required in plugin options under "environments". e.g.: ["e2e"]'
     );
   }
 
-  return <NormalizedCreateNodeOptions>{
+  return {
     environments: {
       environmentsDir: DEFAULT_ENVIRONMENTS_OUTPUT_DIR,
-      targetNames: [DEFAULT_OPTION_ENVIRONMENT_TARGET_NAMES],
+      targetNames: DEFAULT_OPTION_ENVIRONMENT_TARGET_NAMES,
       ...environments,
+      inferredTargets: {
+        ...DEFAULT_ENVIRONMENT_TARGETS,
+        ...environments.inferredTargets,
+      },
     },
     packages: {
       ...packages,
+      inferredTargets: {
+        ...DEFAULT_PACKAGE_TARGETS,
+        ...packages.inferredTargets,
+      },
     },
   };
 }

--- a/projects/nx-verdaccio/src/plugin/nx-verdaccio.plugin.ts
+++ b/projects/nx-verdaccio/src/plugin/nx-verdaccio.plugin.ts
@@ -1,6 +1,5 @@
 import {
   type CreateNodes,
-  type CreateNodesContext,
   createNodesFromFiles,
   type CreateNodesV2,
   logger,
@@ -9,24 +8,20 @@ import {
 } from '@nx/devkit';
 import { readFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { NxVerdaccioCreateNodeOptions } from './schema';
-import {
-  normalizeCreateNodesOptions,
-  type NormalizedCreateNodeOptions,
-} from './normalize-create-nodes-options';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
-import { PLUGIN_NAME } from './constants';
 import {
   getCacheRecord,
   readTargetsCache,
   setCacheRecord,
   writeTargetsToCache,
 } from './caching';
+import { PLUGIN_NAME } from './constants';
+import { normalizeCreateNodesOptions } from './normalize-create-nodes-options';
+import type { NxVerdaccioCreateNodeOptions } from './schema';
 import { createProjectConfiguration } from './targets/create-targets';
 
 const PROJECT_JSON_FILE_GLOB = '**/project.json';
-const PACKAGE_JSON_FILE_GLOB = '**/package.json';
 
 export const createNodesV2: CreateNodesV2<NxVerdaccioCreateNodeOptions> = [
   PROJECT_JSON_FILE_GLOB,
@@ -95,14 +90,9 @@ export const createNodesV2: CreateNodesV2<NxVerdaccioCreateNodeOptions> = [
   },
 ];
 
-export const createNodes: CreateNodes = [
+export const createNodes: CreateNodes<NxVerdaccioCreateNodeOptions> = [
   PROJECT_JSON_FILE_GLOB,
-  (
-    projectConfigurationFile: string,
-    options: NormalizedCreateNodeOptions,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    context: CreateNodesContext
-  ) => {
+  (projectConfigurationFile, options) => {
     logger.info(
       '`createNodes` is deprecated. Update Nx utilize createNodesV2 instead.'
     );

--- a/projects/nx-verdaccio/src/plugin/schema.ts
+++ b/projects/nx-verdaccio/src/plugin/schema.ts
@@ -1,12 +1,19 @@
+import type {
+  NxVerdaccioEnvironmentTarget,
+  NxVerdaccioPackageTarget,
+} from './constants';
+
 export type NxVerdaccioEnvironmentsOptions = {
   environmentsDir?: string;
   targetNames?: string[];
   filterByTags?: string[];
+  inferredTargets?: Record<NxVerdaccioEnvironmentTarget, string>;
 };
 export type NxVerdaccioPackagesOptions = {
   environmentsDir?: string;
   targetNames?: string[];
   filterByTags?: string[];
+  inferredTargets?: Record<NxVerdaccioPackageTarget, string>;
 };
 export type NxVerdaccioCreateNodeOptions = {
   environments?: NxVerdaccioEnvironmentsOptions;

--- a/projects/nx-verdaccio/src/plugin/targets/create-targets.ts
+++ b/projects/nx-verdaccio/src/plugin/targets/create-targets.ts
@@ -1,6 +1,6 @@
-import type { NxVerdaccioCreateNodeOptions } from '../schema';
 import { logger, type ProjectConfiguration } from '@nx/devkit';
 import { normalizeCreateNodesOptions } from '../normalize-create-nodes-options';
+import type { NxVerdaccioCreateNodeOptions } from '../schema';
 import {
   getEnvTargets,
   isEnvProject,
@@ -45,9 +45,7 @@ export function createProjectConfiguration(
       // === ENVIRONMENT TARGETS ===
       targets: {
         // start-verdaccio, stop-verdaccio
-        ...verdaccioTargets(projectConfiguration, {
-          environmentsDir: environments.environmentsDir,
-        }),
+        ...verdaccioTargets(projectConfiguration, environments),
         // env-bootstrap-env, env-setup-env, install-env (intermediate target to run dependency targets)
         ...getEnvTargets(projectConfiguration, environments),
         // adjust targets to run env-setup-env

--- a/projects/nx-verdaccio/src/plugin/utils/type.utils.ts
+++ b/projects/nx-verdaccio/src/plugin/utils/type.utils.ts
@@ -1,0 +1,7 @@
+export type Prettify<T> = {
+  [K in keyof T]: T[K];
+} & {};
+
+export type WithRequired<T, K extends keyof T> = Prettify<
+  Required<Pick<T, K>> & Omit<T, K>
+>;


### PR DESCRIPTION
## Motivation

Even after having used this plugin for some time, I still find typing `npx nx nxv-e2e <project>-e2e` quite cumbersome and error prone - too many `n`s and `x`s :sweat_smile:

Then I had the idea of renaming the inferred `nxv-e2e` target to `e2e-test`, since that combines nicely with other "run tests of only this type" targets like `unit-test` and `int-test`/`integration-test` as is a little more intuitive.

Unfortunately, I'm not able to set it with this way yet because the inferred `nxv-*` targets aren't customizable. So I decided to add `inferredTargets` option under both `environments` and `packages` in the plugin options for this purpose.

## Implementation scope

- Added new `inferredTargets` options.
- Replaced constants like `TARGET_ENVIRONMENT_SETUP` with options object and fallbacks to default values.
  - Applies not only to plugin, but also to executors.
- Adjusted tests and added new E2E test case for the custom target names.
- Added docs to main README.