### PR TITLE
docs: fix markdown links, syntax, etc. + add github <-> npm links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Prerequisites:
 
 - Node.js installed (LTS version).
 
-Make sure to install dependencies from the `package-jock.json`:
+Make sure to install dependencies from the `package-lock.json`:
 
 ```sh
 npm ci
@@ -38,17 +38,14 @@ npx nx run-many -t unit-test
 # run integration tests for all projects
 npx nx run-many -t integration-test
 
-# run E2E tests for CLI
-npx nx e2e cli-e2e
+# run E2E tests for Nx plugin
+npx nx nxv-e2e nx-verdaccio-e2e
 
-# build CLI along with packages it depends on
-npx nx build cli
+# build Nx plugin along with packages it depends on
+npx nx build nx-verdaccio
 
 # lint projects affected by changes (compared to main branch)
 npx nx affected:lint
-
-# run CLI command on this repository
-npx nx cli -- collect
 ```
 
 ## Testing
@@ -67,7 +64,7 @@ Projects have the following testing targets:
 | `e2e`              | General E2E testing target |
 | `e2e-cy`           | Cypress E2E testing        |
 | `e2e-vi`           | Vitest E2E testing         |
-| `e2e-pl`           | Playwrite E2E testing      |
+| `e2e-pl`           | Playwright E2E testing     |
 
 ## Git
 
@@ -89,20 +86,20 @@ Therefore, PRs are merged via one of two strategies:
 
 Projects are tagged in two different dimensions - scope and type:
 
-| tag                 | description                                                            | allowed dependencies                               |
-| :------------------ | :--------------------------------------------------------------------- | :------------------------------------------------- |
-| `scope:core`        | core features and CLI (agnostic towards specific plugins)              | `scope:core` or `scope:shared`                     |
-| `scope:shared`      | data models, utility functions, etc. (not specific to core or plugins) | `scope:shared`                                     |
-| `scope:tooling`     | supplementary tooling, e.g. code generation                            | `scope:tooling`, `scope:shared`                    |
-| `scope:internal`    | internal project, e.g. example e2e                                     | any                                                |
-| `type:app`          | application, e.g. CLI or example web app                               | `type:feature`, `type:util` or `type:testing-util` |
-| `type:feature`      | library with business logic for a specific feature                     | `type:util` or `type:testing-util`                 |
-| `type:util`         | general purpose utilities and types intended for reuse                 | `type:util` or `type:testing-util`                 |
-| `type:e2e`          | E2E testing                                                            | `type:app`, `type:feature` or `type:testing-util`  |
-| `type:e2e-vi`       | E2E testing with vitest                                                | `type:app`, `type:feature` or `type:testing-util`  |
-| `type:e2e-cy`       | E2E testing with cypress                                               | `type:app`, `type:feature` or `type:testing-util`  |
-| `type:e2e-pr`       | E2E testing with playwrite                                             | `type:app`, `type:feature` or `type:testing-util`  |
-| `type:testing-util` | testing utilities                                                      | `type:util`                                        |
+| tag                 | description                                                          | allowed dependencies                               |
+| :------------------ | :------------------------------------------------------------------- | :------------------------------------------------- |
+| `scope:core`        | core features                                                        | `scope:core` or `scope:shared`                     |
+| `scope:shared`      | data models, utility functions, etc. (not specific to core features) | `scope:shared`                                     |
+| `scope:tooling`     | supplementary tooling, e.g. code generation                          | `scope:tooling`, `scope:shared`                    |
+| `scope:internal`    | internal project, e.g. example e2e                                   | any                                                |
+| `type:app`          | application, e.g. CLI or example web app                             | `type:feature`, `type:util` or `type:testing-util` |
+| `type:feature`      | library with business logic for a specific feature                   | `type:util` or `type:testing-util`                 |
+| `type:util`         | general purpose utilities and types intended for reuse               | `type:util` or `type:testing-util`                 |
+| `type:e2e`          | E2E testing                                                          | `type:app`, `type:feature` or `type:testing-util`  |
+| `type:e2e-vi`       | E2E testing with vitest                                              | `type:app`, `type:feature` or `type:testing-util`  |
+| `type:e2e-cy`       | E2E testing with cypress                                             | `type:app`, `type:feature` or `type:testing-util`  |
+| `type:e2e-pr`       | E2E testing with playwright                                          | `type:app`, `type:feature` or `type:testing-util`  |
+| `type:testing-util` | testing utilities                                                    | `type:util`                                        |
 
 ## Special folders
 
@@ -116,8 +113,8 @@ The following optional folders can be present in a project root;
 - `docs` - documentation files specific for a given project
 - `tooling` - tooling related code specific for a given project
 
-# Release
+## Release
 
 ```sh
-nx release
+npx nx release
 ```

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ### 🚀 Enterprise Grade Testing with Verdaccio and Nx ⚡
 
-[![version](https://img.shields.io/github/v/release/push-based/nx-verdaccio)](https://github.com/push-based/nx-verdaccio/releases/latest)
+[![npm](https://img.shields.io/npm/v/%40push-based%2Fnx-verdaccio.svg)](https://www.npmjs.com/package/@push-based/nx-verdaccio)
 [![release date](https://img.shields.io/github/release-date/push-based/nx-verdaccio)](https://github.com/push-based/nx-verdaccio/releases)
 [![license](https://img.shields.io/github/license/push-based/nx-verdaccio)](https://opensource.org/licenses/MIT)
 [![commit activity](https://img.shields.io/github/commit-activity/m/push-based/nx-verdaccio)](https://github.com/push-based/nx-verdaccio/pulse/monthly)

--- a/docs/benefits.md
+++ b/docs/benefits.md
@@ -3,13 +3,13 @@
 Game changing **scalable** and **maintainable** setup for Verdaccio.
 
 > [!NOTE]
-> 💡 Learn more about the common problems with shared environments in the **💡[docs/motivation.md](./docs/motivation.md)💡**.
+> 💡 Learn more about the common problems with shared environments in the **💡[docs/motivation.md](./motivation.md)💡**.
 
 #### Project Graph
 
 Here the project graph of the research.
 
-![utils-project-graph-idle.png](docs%2Futils-project-graph-idle.png)
+![utils-project-graph-idle.png](./utils-project-graph-idle.png)
 
 ## 🛡️ Environment Folders to Isolate Files During E2E Tests
 
@@ -61,7 +61,7 @@ This allows us to **cache** the environment and **reuse** it across tests, leadi
 - 🔥 No need to uninstall packages or delete storage folders manually. We can simply delete the isolated folder when needed.
 - 🔥 The system only installs the necessary packages, further reducing time and resource usage.
 
-![testing-dx--schema-good.png](testing-dx--schema-good.png)
+![testing-dx--schema-good.png](./testing-dx--schema-good.png)
 
 ### Changes in source
 
@@ -111,7 +111,7 @@ This approach makes the E2E setup more **maintainable** and easier to serve edge
 - The NX task graph provides a clear visual overview of the process, making it easy to see what runs when and how the environment is set up.
 - Configuring a test setup is in a single place and provides fine-grained configuration
 
-![utils-task-graph-idle.png](docs%2Futils-task-graph-idle.png)
+![utils-task-graph-idle.png](./utils-task-graph-idle.png)
 
 In summary, this new setup offers a more scalable, maintainable, and performant way to handle E2E testing.
 By isolating environments and using NX’s powerful tools, it becomes easier to run, manage, and debug E2E tests across projects.

--- a/docs/motivation.md
+++ b/docs/motivation.md
@@ -1,16 +1,16 @@
 # Motivation
 
 The following document explains the motivation behind this library and the problem it solves.
-We will discuss [common E2e setup for publishable packages](#Common-E2E-setup-for-publishable-packages) in the wild, what problems they have and why they are pretty limited in their scalability and performance.
+We will discuss [common E2E setup for publishable packages](#common-e2e-setup-for-publishable-packages) in the wild, what problems they have and why they are pretty limited in their scalability and performance.
 
 > [!NOTE]
-> 💡 Learn more about tthe benefits of nx-verdaccio **💡[docs/benefits.md](benefits.md)💡**.
+> 💡 Learn more about the benefits of nx-verdaccio in **💡[docs/benefits.md](./benefits.md)💡**.
 
 #### Project Graph
 
 Here the project graph of the research.
 
-![utils-project-graph-idle.png](docs%2Futils-project-graph-idle.png)
+![utils-project-graph-idle.png](./utils-project-graph-idle.png)
 
 Before we go into more detail let's quickly list the problems here to later on dive into each of them individually:
 
@@ -87,7 +87,7 @@ Viola, you have a working e2e setup for your package. 🎉
 
 Here the project graph of the research.
 
-![utils-project-graph-idle.png](utils-project-graph-idle.png)
+![utils-project-graph-idle.png](./utils-project-graph-idle.png)
 
 ## 🚪 Isolation of the E2E tests
 
@@ -147,7 +147,7 @@ To run 1 E2E test the following chain has to happen:
 - Start Verdaccio server - to be able to publish packages to and install from
 - NPM publish the package to the Verdaccio server
 - NPM install the package to the Start Verdaccio server
-- Execute the actual e2e tests over playwrite, vitest, jest or other test runner
+- Execute the actual E2E tests over Playwright, Vitest, Jest or other test runner
 - NPM uninstall the package from the local setup
 - Stop the Verdaccio server
 - Delete the storage folder
@@ -171,7 +171,7 @@ If we would not have to keep the server running for the whole test we can also:
 - 🐢 Stop wasting CPU power and memory that is consumed by the server
 - 🐢 Think about options to cache parts of the steps
 
-![task-architecture--schema-bad.png](task-architecture--schema-bad.png)
+![task-architecture--schema-bad.png](./task-architecture--schema-bad.png)
 
 Especially the caching is interesting to dive deeper in.
 Let's look at different scenarios and what they miss.

--- a/projects/nx-verdaccio/README.md
+++ b/projects/nx-verdaccio/README.md
@@ -12,7 +12,7 @@ See [nx-verdaccio plugin docs](./src/plugin/README.md) for details
 
 ### Setup Environment Executor
 
-This executor helps to initiate an [environment folder](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests) and installs it`s dependent projects.
+This executor helps to initiate an [environment folder](../../docs/benefits.md#-environment-folders-to-isolate-files-during-e2e-tests) and installs it's dependent projects.
 
 ```jsonc
 // project.json
@@ -22,8 +22,8 @@ This executor helps to initiate an [environment folder](../../../../../README.md
     "env-setup": {
       "executor": "@code-pushup/nx-verdaccio:env-setup",
       "options": {
-        "skipInstall": true
-        "keepServerRunning": true
+        "skipInstall": true,
+        "keepServerRunning": true,
         "envRoot": "/tmp/test-npm-workspace"
       }
     }
@@ -31,11 +31,11 @@ This executor helps to initiate an [environment folder](../../../../../README.md
 }
 ```
 
-Read more under [setup executor docs](./projects/nx-verdaccio/src/executors/env-setup/README.md).
+Read more under [setup executor docs](./src/executors/env-setup/README.md).
 
 ### Bootstrap Environment Executor
 
-This executor helps to initiate [environment](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests) into a given folder.
+This executor helps to initiate [environment](../../docs/benefits.md#-environment-folders-to-isolate-files-during-e2e-tests) into a given folder.
 
 ```jsonc
 // project.json
@@ -45,16 +45,16 @@ This executor helps to initiate [environment](../../../../../README.md#-environm
     "nx-verdaccio-env-bootstrap": {
       "executor": "@code-pushup/nx-verdaccio:env-bootstrap",
       "options": {
-        "keepServerRunning": false
-        "envRoot": "/tmp/test-npm-workspace"
-        "verbose": true,
+        "keepServerRunning": false,
+        "envRoot": "/tmp/test-npm-workspace",
+        "verbose": true
       }
     }
   }
 }
 ```
 
-Read more under [bootstrap executor docs](./projects/nx-verdaccio/src/executors/env-bootstrap/README.md).
+Read more under [bootstrap executor docs](./src/executors/env-bootstrap/README.md).
 
 ### Kill Process Executor
 
@@ -66,24 +66,24 @@ This executor helps to kill processes by `ProcessID` or a JSON file containing a
   "name": "my-project",
   "targets": {
     "nx-verdaccio-kill-process": {
-      "executor": "@push-based/nx-verdaccio:kill-process"
+      "executor": "@push-based/nx-verdaccio:kill-process",
       "options": {
-        "pid": "42312"
-        "filePath": "/tmp/test-npm-workspace/process-id.json"
-        "verbose": true,
+        "pid": "42312",
+        "filePath": "/tmp/test-npm-workspace/process-id.json",
+        "verbose": true
       }
     }
   }
 }
 ```
 
-Read more under [kill-process executor docs](./projects/nx-verdaccio/src/executors/kill-process/README.md).
+Read more under [kill-process executor docs](./src/executors/kill-process/README.md).
 
 ### NPM Install Executor
 
-This executor helps to install a [`pubishable`](../../../../../README.md#fine-grained-selection-of-publishable-projects) projects into a given [environment folder](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests).
+This executor helps to install a [`publishable`](../../README.md#fine-grained-control-for-publishable-projects-) projects into a given [environment folder](../../docs/benefits.md#-environment-folders-to-isolate-files-during-e2e-tests).
 
-// project.json
+In `project.json`:
 
 ```jsonc
 {
@@ -92,22 +92,22 @@ This executor helps to install a [`pubishable`](../../../../../README.md#fine-gr
     "nx-verdaccio-npm-install": {
       "executor": "@code-pushup/nx-verdaccio:pkg-install",
       "options": {
-        "pkgVersion": "1.2.3"
-        "envRoot": "/tmp/test-npm-workspace"
-        "verbose": true,
+        "pkgVersion": "1.2.3",
+        "envRoot": "/tmp/test-npm-workspace",
+        "verbose": true
       }
     }
   }
 }
 ```
 
-Read more under [pkg install executor docs](./projects/nx-verdaccio/src/executors/pkg-install/README.md).
+Read more under [pkg install executor docs](./src/executors/pkg-install/README.md).
 
 ### NPM Publish Executor
 
-This executor helps to publish a [`pubishable`](../../../../../README.md#fine-grained-selection-of-publishable-projects) projects into a given [environment folder](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests).
+This executor helps to publish a [`publishable`](../../README.md#fine-grained-control-for-publishable-projects-) projects into a given [environment folder](../../docs/benefits.md#-environment-folders-to-isolate-files-during-e2e-tests).
 
-// project.json
+In `project.json`:
 
 ```jsonc
 {
@@ -116,16 +116,16 @@ This executor helps to publish a [`pubishable`](../../../../../README.md#fine-gr
     "nx-verdaccio-npm-publish": {
       "executor": "@code-pushup/nx-verdaccio:pkg-publish",
       "options": {
-        "pkgVersion": "1.2.3"
-        "envRoot": "/tmp/test-npm-workspace"
-        "verbose": true,
+        "pkgVersion": "1.2.3",
+        "envRoot": "/tmp/test-npm-workspace",
+        "verbose": true
       }
     }
   }
 }
 ```
 
-Read more under [pkg publish executor docs](./projects/nx-verdaccio/src/executors/pkg-publish/README.md).
+Read more under [pkg publish executor docs](./src/executors/pkg-publish/README.md).
 
 ## Debugging e2e environments
 

--- a/projects/nx-verdaccio/README.md
+++ b/projects/nx-verdaccio/README.md
@@ -1,5 +1,9 @@
 # @push-based/nx-verdaccio
 
+[![npm](https://img.shields.io/npm/v/%40push-based%2Fnx-verdaccio.svg)](https://www.npmjs.com/package/@push-based/nx-verdaccio)
+[![downloads](https://img.shields.io/npm/dm/%40push-based%2Fnx-verdaccio)](https://npmtrends.com/@push-based/nx-verdaccio)
+[![dependencies](https://img.shields.io/librariesio/release/npm/%40push-based/nx-verdaccio)](https://www.npmjs.com/package/@push-based/nx-verdaccio?activeTab=dependencies)
+
 ## 🔌 Plugins
 
 ### Verdaccio Test Environment Plugin

--- a/projects/nx-verdaccio/package.json
+++ b/projects/nx-verdaccio/package.json
@@ -4,6 +4,15 @@
   "description": "Nx plugin for blazing fast Verdaccio setup & testing",
   "license": "MIT",
   "private": false,
+  "homepage": "https://github.com/push-based/nx-verdaccio#readme",
+  "bugs": {
+    "url": "https://github.com/push-based/nx-verdaccio/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%F0%9F%90%9B%20bug%22"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/push-based/nx-verdaccio.git",
+    "directory": "projects/nx-verdaccio"
+  },
   "dependencies": {
     "@nx/devkit": "19.8.0",
     "ansis": "^3.3.2",

--- a/projects/nx-verdaccio/src/executors/env-bootstrap/README.md
+++ b/projects/nx-verdaccio/src/executors/env-bootstrap/README.md
@@ -1,6 +1,6 @@
 # Bootstrap Environment Executor
 
-This executor helps to initiate [environment](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests) into a given folder.
+This executor helps to initiate [environment](../../../../../docs/benefits.md#️-environment-folders-to-isolate-files-during-e2e-tests) into a given folder.
 This folder contains all needed configuration and files for a Verdaccio registry as well as the package manager configuration.
 
 **Environment folder**
@@ -36,7 +36,7 @@ Root/
 
 ## Usage
 
-// project.json
+In `project.json`:
 
 ```json
 {
@@ -58,9 +58,9 @@ By default, the Nx executor will derive the options from the executor options.
     "env-bootstrap": {
       "executor": "@code-pushup/nx-verdaccio:env-bootstrap",
       "options": {
-        "keepServerRunning": false
-        "envRoot": "/tmp/test-npm-workspace"
-        "verbose": true,
+        "keepServerRunning": false,
+        "envRoot": "/tmp/test-npm-workspace",
+        "verbose": true
       }
     }
   }
@@ -73,7 +73,7 @@ Show what will be executed without actually executing it:
 
 ## Options
 
-| Name                  | type                     | description                                                                                                                          |
+| Name                  | Type                     | Description                                                                                                                          |
 | --------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------------------------------ |
 | **envRoot**           | `string` (REQUIRED)      | The folder in which the package should get published. This folder is the environment folder and contains a configured `.npmrc` file. |
 | **keepServerRunning** | `boolean` (DEFAULT true) | keep the Verdaccio server running after bootstraping the environment                                                                 |

--- a/projects/nx-verdaccio/src/executors/env-setup/README.md
+++ b/projects/nx-verdaccio/src/executors/env-setup/README.md
@@ -1,6 +1,6 @@
 # Setup Environment Executor
 
-This executor helps to initiate an [environment folder](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests) and installs it`s dependent projects.
+This executor helps to initiate an [environment folder](../../../../../docs/benefits.md#️-environment-folders-to-isolate-files-during-e2e-tests) and installs it's dependent projects.
 After running this task a ready to use environment is set up with packages published and installed with Verdaccio.
 
 #### @push-based/nx-verdaccio:env-setup
@@ -33,9 +33,9 @@ By default, the Nx executor will derive the options from the executor options.
     "env-setup": {
       "executor": "@code-pushup/nx-verdaccio:env-setup",
       "options": {
-        "keepServerRunning": false
-        "envRoot": "/tmp/test-npm-workspace"
-        "verbose": true,
+        "keepServerRunning": false,
+        "envRoot": "/tmp/test-npm-workspace",
+        "verbose": true
       }
     }
   }
@@ -48,7 +48,7 @@ Show what will be executed without actually executing it:
 
 ## Options
 
-| Name                  | type                      | description                                                                                                                          |
+| Name                  | Type                      | Description                                                                                                                          |
 | --------------------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | **envRoot**           | `string` (REQUIRED)       | The folder in which the package should get published. This folder is the environment folder and contains a configured `.npmrc` file. |
 | **keepServerRunning** | `boolean` (DEFAULT false) | keep the Verdaccio server running after bootstraping the environment                                                                 |

--- a/projects/nx-verdaccio/src/executors/kill-process/README.md
+++ b/projects/nx-verdaccio/src/executors/kill-process/README.md
@@ -6,7 +6,7 @@ This executor helps to kill processes by `ProcessID` or a JSON file containing a
 
 ## Usage
 
-// project.json
+In `project.json`:
 
 ```json
 {
@@ -26,11 +26,11 @@ By default, the Nx executor will derive the options from the executor options.
   "name": "my-project",
   "targets": {
     "kill-process": {
-      "executor": "@push-based/nx-verdaccio:kill-process"
+      "executor": "@push-based/nx-verdaccio:kill-process",
       "options": {
-        "pid": "42312"
-        "filePath": "/tmp/test-npm-workspace/process-id.json"
-        "verbose": true,
+        "pid": "42312",
+        "filePath": "/tmp/test-npm-workspace/process-id.json",
+        "verbose": true
       }
     }
   }
@@ -43,8 +43,8 @@ Show what will be executed without actually executing it:
 
 ## Options
 
-| Name         | type     | description                                            |
-| ------------ | -------- | ------------------------------------------------------ |
-| **pid**      | `number` | Process ID to kill                                     |
-| **filePath** | `string` | Path to JSON file contaning a `pid` property as number |
-| **verbose**  | `bolean` | Show more verbose logs                                 |
+| Name         | Type      | Description                                            |
+| ------------ | --------- | ------------------------------------------------------ |
+| **pid**      | `number`  | Process ID to kill                                     |
+| **filePath** | `string`  | Path to JSON file contaning a `pid` property as number |
+| **verbose**  | `boolean` | Show more verbose logs                                 |

--- a/projects/nx-verdaccio/src/executors/pkg-install/README.md
+++ b/projects/nx-verdaccio/src/executors/pkg-install/README.md
@@ -1,6 +1,6 @@
 # NPM Install Executor
 
-This executor helps to install a [`pubishable`](../../../../../README.md#fine-grained-selection-of-publishable-projects) projects into a given [environment folder](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests).
+This executor helps to install a [`publishable`](../../../../../README.md#fine-grained-control-for-publishable-projects-) projects into a given [environment folder](../../../../../docs/benefits.md#️-environment-folders-to-isolate-files-during-e2e-tests).
 This folder has to contain all needed configuration and files for the `npm install` command to work.
 
 #### @push-based/nx-verdaccio:pkg-install
@@ -11,7 +11,7 @@ This folder has to contain all needed configuration and files for the `npm insta
 
 ## Usage
 
-// project.json
+In `project.json`:
 
 ```json
 {
@@ -33,9 +33,9 @@ By default, the Nx executor will derive the options from the executor options.
     "pkg-install": {
       "executor": "@code-pushup/nx-verdaccio:pkg-install",
       "options": {
-        "pkgVersion": "1.2.3"
-        "envRoot": "/tmp/test-npm-workspace"
-        "verbose": true,
+        "pkgVersion": "1.2.3",
+        "envRoot": "/tmp/test-npm-workspace",
+        "verbose": true
       }
     }
   }
@@ -48,8 +48,8 @@ Show what will be executed without actually executing it:
 
 ## Options
 
-| Name           | type     | description                                                                                                                          |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **pkgVersion** | `string` | The packages version to install. Falls back to get the current version from build output.                                            |
-| **envRoot**    | `string` | The folder in which the package should get installed. This folder is the environment folder and contains a configured `.npmrc` file. |
-| **verbose**    | `bolean` | Show more verbose logs                                                                                                               |
+| Name           | Type      | Description                                                                                                                          |
+| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **pkgVersion** | `string`  | The packages version to install. Falls back to get the current version from build output.                                            |
+| **envRoot**    | `string`  | The folder in which the package should get installed. This folder is the environment folder and contains a configured `.npmrc` file. |
+| **verbose**    | `boolean` | Show more verbose logs                                                                                                               |

--- a/projects/nx-verdaccio/src/executors/pkg-publish/README.md
+++ b/projects/nx-verdaccio/src/executors/pkg-publish/README.md
@@ -1,6 +1,6 @@
 # NPM Publish Executor
 
-This executor helps to publish a [`pubishable`](../../../../../README.md#fine-grained-selection-of-publishable-projects) projects into a given [environment folder](../../../../../README.md#-environment-folders-to-isolate-files-during-e2e-tests).
+This executor helps to publish a [`publishable`](../../../../../README.md#fine-grained-control-for-publishable-projects-) projects into a given [environment folder](../../../../../docs/benefits.md#️-environment-folders-to-isolate-files-during-e2e-tests).
 This folder has to contain all needed configuration and files for the `npm publish` command to work.
 
 #### @push-based/nx-verdaccio:release-publish
@@ -11,7 +11,7 @@ This folder has to contain all needed configuration and files for the `npm publi
 
 ## Usage
 
-// project.json
+In `project.json`:
 
 ```json
 {
@@ -33,9 +33,9 @@ By default, the Nx executor will derive the options from the executor options.
     "pkg-publish": {
       "executor": "@code-pushup/nx-verdaccio:pkg-publish",
       "options": {
-        "pkgVersion": "1.2.3"
-        "envRoot": "/tmp/test-npm-workspace"
-        "verbose": true,
+        "pkgVersion": "1.2.3",
+        "envRoot": "/tmp/test-npm-workspace",
+        "verbose": true
       }
     }
   }
@@ -48,8 +48,8 @@ Show what will be executed without actually executing it:
 
 ## Options
 
-| Name           | type     | description                                                                                                                          |
-| -------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| **pkgVersion** | `string` | The packages version to publish. Falls back to get the current version from build output.                                            |
-| **envRoot**    | `string` | The folder in which the package should get published. This folder is the environment folder and contains a configured `.npmrc` file. |
-| **verbose**    | `bolean` | Show more verbose logs                                                                                                               |
+| Name           | Type      | Description                                                                                                                          |
+| -------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| **pkgVersion** | `string`  | The packages version to publish. Falls back to get the current version from build output.                                            |
+| **envRoot**    | `string`  | The folder in which the package should get published. This folder is the environment folder and contains a configured `.npmrc` file. |
+| **verbose**    | `boolean` | Show more verbose logs                                                                                                               |

--- a/projects/nx-verdaccio/src/plugin/README.md
+++ b/projects/nx-verdaccio/src/plugin/README.md
@@ -1,13 +1,13 @@
 # Verdaccio Testing Environments Nx Plugin
 
-This plugin helps to add dynamic targets to execute environment tasks. 
+This plugin helps to add dynamic targets to execute environment tasks.
 This distinguishes between projects that maintain publishable packages and e2e test projects that depend on an environment where the publishable projects get installed.
 
 #### @push-based/nx-verdaccio
 
 ## Usage
 
-// `nx.json`:
+In `nx.json`:
 
 ```jsonc
 {
@@ -16,8 +16,8 @@ This distinguishes between projects that maintain publishable packages and e2e t
       "plugin": "@push-based/nx-verdaccio",
       "options": {
         "environments": {
-            "environmentsDir": "tmp/environments" // Optional
-            "targetNames": ["e2e"] // Optional
+          "environmentsDir": "tmp/environments", // Optional
+          "targetNames": ["e2e"] // Optional
         }
       }
     }
@@ -29,7 +29,7 @@ Now run your e2e test with `nx run utils-e2e:e2e`
 
 ## Options
 
-| Name                             | type                                  | description                                                                                  |
+| Name                             | Type                                  | Description                                                                                  |
 | -------------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------- |
 | **environments.environmentsDir** | `string` (DEFAULT 'tmp/environments') | The folder name of the generated environments                                                |
 | **environments.targetNames**     | `string[]` (REQUIRED)                 | The target names of projects depending on environments                                       |


### PR DESCRIPTION
Made various fixes to Markdown docs:
- broken links
- invalid JSON syntax
- copy/pasted contributing examples from `code-pushup/cli`
- typographic inconsistencies

Also added:
- npm package metadata (links to GitHub)
- badges in READMEs (links to npm)